### PR TITLE
feat: add namespacing to tool names to avoid collisions across MCP servers

### DIFF
--- a/docs/TOOL_NAMESPACING.md
+++ b/docs/TOOL_NAMESPACING.md
@@ -1,0 +1,265 @@
+# Tool Namespacing in North MCP Python SDK
+
+## Overview
+
+The North MCP Python SDK includes built-in tool namespacing functionality to prevent tool name collisions when multiple MCP servers are used together. This feature automatically prefixes tool names with a normalized version of the server name.
+
+## Why Tool Namespacing?
+
+When multiple MCP servers are running in the same environment, tool name collisions can occur. For example:
+
+- A calculator server might have an `add` tool for mathematical operations
+- A Slack server might have an `add` tool for adding users to channels
+- A database server might have an `add` tool for inserting records
+
+Without namespacing, these tools would conflict. With namespacing enabled, they become:
+
+- `calculator_add`
+- `slack_add` 
+- `database_add`
+
+## Usage
+
+### Basic Usage
+
+Namespacing is **enabled by default** when you create a `NorthMCPServer`:
+
+```python
+from north_mcp_python_sdk import NorthMCPServer
+
+# Create server with namespacing enabled (default)
+mcp = NorthMCPServer("Demo Calculator", port=5222)
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b
+
+@mcp.tool()
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers"""
+    return a * b
+
+# Tools will be registered as:
+# - demo_calculator_add
+# - demo_calculator_multiply
+```
+
+### Disabling Namespacing
+
+You can disable namespacing by setting `namespace=False`:
+
+```python
+# Create server without namespacing
+mcp = NorthMCPServer("Simple Server", namespace=False)
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b
+
+# Tool will be registered as:
+# - add (no prefix)
+```
+
+### Custom Tool Names
+
+Custom tool names work with namespacing:
+
+```python
+mcp = NorthMCPServer("Math Server", namespace=True)
+
+@mcp.tool(name="custom_division")
+def divide(a: float, b: float) -> float:
+    """Divide two numbers"""
+    return a / b
+
+# Tool will be registered as:
+# - math_server_custom_division
+```
+
+## Namespace Normalization
+
+Server names are automatically normalized to create valid namespace identifiers:
+
+| Server Name | Normalized Namespace |
+|-------------|---------------------|
+| `"Demo"` | `demo` |
+| `"Slack Dev"` | `slack_dev` |
+| `"My-Server"` | `my_server` |
+| `"Calculator 2.0!"` | `calculator_2_0` |
+| `"API@Server#1"` | `api_server_1` |
+
+The normalization process:
+
+1. Converts to lowercase
+2. Replaces non-alphanumeric characters with underscores
+3. Removes leading/trailing underscores
+4. Collapses multiple consecutive underscores into single underscores
+5. Falls back to `"server"` for empty or invalid names
+
+## Examples
+
+### Multiple Servers Without Collisions
+
+```python
+from north_mcp_python_sdk import NorthMCPServer
+
+# Calculator server
+calc_server = NorthMCPServer("Basic Calculator", port=5222)
+
+@calc_server.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b
+
+@calc_server.tool()
+def calculate(expression: str) -> str:
+    """Evaluate mathematical expression"""
+    return str(eval(expression))
+
+# Slack server  
+slack_server = NorthMCPServer("Slack Dev", port=5223)
+
+@slack_server.tool()
+def add(channel: str, user: str) -> dict:
+    """Add user to channel"""
+    return {"added": user, "to": channel}
+
+@slack_server.tool()
+def list_channels() -> list:
+    """List all channels"""
+    return [{"name": "general"}, {"name": "random"}]
+
+# Resulting tools:
+# Calculator: basic_calculator_add, basic_calculator_calculate
+# Slack: slack_dev_add, slack_dev_list_channels
+```
+
+### Mixed Namespacing
+
+```python
+# Namespaced server
+namespaced = NorthMCPServer("Special Tools", namespace=True)
+
+@namespaced.tool()
+def special_function() -> str:
+    return "namespaced"
+
+# Non-namespaced server
+simple = NorthMCPServer("Simple Tools", namespace=False)
+
+@simple.tool()
+def simple_function() -> str:
+    return "not namespaced"
+
+# Resulting tools:
+# - special_tools_special_function
+# - simple_function
+```
+
+## API Reference
+
+### NorthMCPServer Parameters
+
+```python
+def __init__(
+    self,
+    name: str | None = None,
+    instructions: str | None = None,
+    server_secret: str | None = None,
+    auth_server_provider: OAuthAuthorizationServerProvider | None = None,
+    debug: bool | None = None,
+    namespace: bool = True,  # NEW: Enable/disable namespacing
+    **settings: Any,
+):
+```
+
+**Parameters:**
+
+- `namespace` (bool, default=True): Whether to enable tool namespacing
+  - `True`: Tools are prefixed with normalized server name using underscore separator
+  - `False`: Tools use their original names without prefixes
+
+### Utility Functions
+
+```python
+from north_mcp_python_sdk import _normalize_namespace
+
+# Get normalized namespace for a server name
+namespace = _normalize_namespace("My Server 2.0!")
+print(namespace)  # Output: "my_server_2_0"
+```
+
+## Best Practices
+
+1. **Use descriptive server names**: The server name becomes the namespace prefix, so choose names that clearly identify the server's purpose.
+
+2. **Keep namespaces consistent**: If you're building a suite of related servers, use consistent naming patterns.
+
+3. **Consider namespace length**: Very long server names result in long tool names. Keep server names reasonably concise.
+
+4. **Test tool names**: Use the provided examples or tests to verify your tool names are what you expect.
+
+5. **Document your tools**: Include clear descriptions for tools, especially when namespacing creates longer tool names.
+
+## Troubleshooting
+
+### Tool Names Not What Expected
+
+Check the normalized namespace:
+
+```python
+server = NorthMCPServer("Your Server Name")
+print(f"Namespace: {server._namespace_prefix}")
+
+tools = server._tool_manager.list_tools()
+for tool in tools:
+    print(f"Tool: {tool.name}")
+```
+
+### Disabling Namespacing Temporarily
+
+For debugging or migration purposes:
+
+```python
+# Temporarily disable namespacing
+server = NorthMCPServer("My Server", namespace=False)
+```
+
+### Custom Namespace Logic
+
+If you need custom namespace logic, you can subclass `NorthMCPServer`:
+
+```python
+class CustomNorthMCPServer(NorthMCPServer):
+    def _get_namespaced_tool_name(self, name: str) -> str:
+        # Custom namespace logic here
+        if self._namespace_enabled:
+            return f"custom_{self._namespace_prefix}_{name}"
+        return name
+```
+
+## Migration Guide
+
+### From Non-Namespaced to Namespaced
+
+If you're migrating existing servers to use namespacing:
+
+1. **Identify current tool names** in your MCP clients
+2. **Update client code** to use the new namespaced tool names
+3. **Test thoroughly** to ensure all tool calls work correctly
+
+### Gradual Migration
+
+You can migrate gradually by running both versions:
+
+```python
+# Old server (no namespacing)
+old_server = NorthMCPServer("Calculator", port=5222, namespace=False)
+
+# New server (with namespacing)  
+new_server = NorthMCPServer("Calculator", port=5223, namespace=True)
+
+# Gradually migrate clients from port 5222 to 5223
+```

--- a/examples/server_with_namespacing.py
+++ b/examples/server_with_namespacing.py
@@ -1,0 +1,132 @@
+"""
+Example demonstrating tool namespacing to prevent tool name collisions.
+
+This example shows how different servers can use the same tool function names
+without conflicts by using namespaces.
+"""
+
+from north_mcp_python_sdk import NorthMCPServer
+
+
+def create_calculator_server():
+    """Create a calculator server with namespace 'basic_calculator'"""
+    mcp = NorthMCPServer("Basic Calculator", port=5224, namespace=True)
+
+    @mcp.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers"""
+        return a + b
+
+    @mcp.tool()
+    def multiply(a: int, b: int) -> int:
+        """Multiply two numbers"""
+        return a * b
+
+    @mcp.tool()
+    def calculate(expression: str) -> str:
+        """Evaluate a mathematical expression"""
+        try:
+            # Simple evaluation - in production, use a safer parser
+            result = eval(expression, {"__builtins__": {}})
+            return f"{expression} = {result}"
+        except Exception as e:
+            return f"Error: {e}"
+
+    return mcp
+
+
+def create_slack_server():
+    """Create a Slack server with namespace 'slack_dev'"""
+    mcp = NorthMCPServer("Slack Dev", port=5225, namespace=True)
+
+    @mcp.tool()
+    def list_channels() -> list[dict]:
+        """List all Slack channels"""
+        return [
+            {"id": "C1234567890", "name": "general", "members": 42},
+            {"id": "C0987654321", "name": "random", "members": 28},
+            {"id": "C1122334455", "name": "development", "members": 15}
+        ]
+
+    @mcp.tool()
+    def send_message(channel: str, message: str) -> dict:
+        """Send a message to a Slack channel"""
+        return {
+            "channel": channel,
+            "message": message,
+            "timestamp": "1234567890.123",
+            "status": "sent"
+        }
+
+    @mcp.tool()
+    def get_user_info(user_id: str) -> dict:
+        """Get information about a Slack user"""
+        return {
+            "id": user_id,
+            "name": "John Doe",
+            "email": "john.doe@company.com",
+            "status": "active"
+        }
+
+    return mcp
+
+
+def create_no_namespace_server():
+    """Create a server without namespacing"""
+    mcp = NorthMCPServer("No Namespace Demo", port=5226, namespace=False)
+
+    @mcp.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers (no namespace)"""
+        return a + b
+
+    @mcp.tool()
+    def info() -> dict:
+        """Get server information"""
+        return {
+            "server": "No Namespace Demo",
+            "namespace": "disabled",
+            "tools": ["add", "info"]
+        }
+
+    return mcp
+
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) != 2:
+        print("Usage: python server_with_namespacing.py [calculator|slack|no-namespace]")
+        print("This will create tools with the following names:")
+        print("\nCalculator server (namespace: basic_calculator):")
+        print("  - basic_calculator_add")
+        print("  - basic_calculator_multiply")
+        print("  - basic_calculator_calculate")
+        print("\nSlack server (namespace: slack_dev):")
+        print("  - slack_dev_list_channels")
+        print("  - slack_dev_send_message")
+        print("  - slack_dev_get_user_info")
+        print("\nNo namespace server:")
+        print("  - add")
+        print("  - info")
+        sys.exit(1)
+    
+    server_type = sys.argv[1]
+    
+    if server_type == "calculator":
+        server = create_calculator_server()
+        print("Starting Basic Calculator server on port 5224...")
+        print("Tools will be prefixed with 'basic_calculator_'")
+    elif server_type == "slack":
+        server = create_slack_server()
+        print("Starting Slack Dev server on port 5225...")
+        print("Tools will be prefixed with 'slack_dev_'")
+    elif server_type == "no-namespace":
+        server = create_no_namespace_server()
+        print("Starting No Namespace server on port 5226...")
+        print("Tools will have no namespace prefix")
+    else:
+        print(f"Unknown server type: {server_type}")
+        sys.exit(1)
+    
+    server.run(transport="streamable-http")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/__init__.py
+++ b/src/north_mcp_python_sdk/__init__.py
@@ -1,9 +1,11 @@
 import logging
 import os
-from typing import Any
+import re
+from typing import Any, Callable
 
 from mcp.server.auth.provider import OAuthAuthorizationServerProvider
 from mcp.server.fastmcp import FastMCP
+from mcp.types import AnyFunction, ToolAnnotations
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
@@ -16,6 +18,26 @@ def is_debug_mode() -> bool:
     return os.getenv('DEBUG', '').lower() in ('true', '1', 'yes', 'on')
 
 
+__all__ = ["NorthMCPServer", "_normalize_namespace", "is_debug_mode"]
+
+
+def _normalize_namespace(name: str) -> str:
+    """Convert a server name to a valid namespace identifier.
+    
+    Examples:
+        "Demo" -> "demo"
+        "Slack Dev" -> "slack_dev"
+        "My-Server" -> "my_server"
+        "Calculator 2.0!" -> "calculator_2_0"
+    """
+    # Convert to lowercase and replace non-alphanumeric characters with underscores
+    normalized = re.sub(r'[^a-zA-Z0-9]+', '_', name.lower())
+    # Remove leading/trailing underscores and multiple consecutive underscores
+    normalized = re.sub(r'^_+|_+$', '', normalized)
+    normalized = re.sub(r'_+', '_', normalized)
+    return normalized or 'server'
+
+
 class NorthMCPServer(FastMCP):
     def __init__(
         self,
@@ -25,10 +47,15 @@ class NorthMCPServer(FastMCP):
         auth_server_provider: OAuthAuthorizationServerProvider[Any, Any, Any]
         | None = None,
         debug: bool | None = None,
+        namespace: bool = True,
         **settings: Any,
     ):
         super().__init__(name, instructions, auth_server_provider, **settings)
         self._server_secret = server_secret
+        
+        # Set up namespacing
+        self._namespace_enabled = namespace
+        self._namespace_prefix = _normalize_namespace(name) if name and namespace else None
         
         # Auto-enable debug mode from environment variable if not explicitly set
         if debug is None:
@@ -47,6 +74,72 @@ class NorthMCPServer(FastMCP):
         else:
             self._logger = logging.getLogger(f"NorthMCP.{name or 'Server'}")
             self._logger.setLevel(logging.INFO)
+
+    def _get_namespaced_tool_name(self, name: str) -> str:
+        """Get the namespaced tool name if namespacing is enabled."""
+        if self._namespace_enabled and self._namespace_prefix:
+            return f"{self._namespace_prefix}_{name}"
+        return name
+
+    def add_tool(
+        self,
+        fn: AnyFunction,
+        name: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | None = None,
+    ) -> None:
+        """Add a tool to the server with optional namespacing.
+
+        If namespacing is enabled, the tool name will be prefixed with the server namespace.
+
+        Args:
+            fn: The function to register as a tool
+            name: Optional name for the tool (defaults to function name)
+            description: Optional description of what the tool does
+            annotations: Optional ToolAnnotations providing additional tool information
+        """
+        tool_name = name or fn.__name__
+        namespaced_name = self._get_namespaced_tool_name(tool_name)
+        super().add_tool(fn, name=namespaced_name, description=description, annotations=annotations)
+
+    def tool(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | None = None,
+    ) -> Callable[[AnyFunction], AnyFunction]:
+        """Decorator to register a tool with optional namespacing.
+
+        If namespacing is enabled, the tool name will be prefixed with the server namespace.
+
+        Args:
+            name: Optional name for the tool (defaults to function name)
+            description: Optional description of what the tool does
+            annotations: Optional ToolAnnotations providing additional tool information
+
+        Example:
+            # With namespace "demo", this creates tool "demo/add"
+            @server.tool()
+            def add(x: int, y: int) -> int:
+                return x + y
+
+            # With namespace "demo", this creates tool "demo/custom_name"
+            @server.tool(name="custom_name")
+            def my_func() -> str:
+                return "hello"
+        """
+        # Check if user passed function directly instead of calling decorator
+        if callable(name):
+            raise TypeError(
+                "The @tool decorator was used incorrectly. "
+                "Did you forget to call it? Use @tool() instead of @tool"
+            )
+
+        def decorator(fn: AnyFunction) -> AnyFunction:
+            self.add_tool(fn, name=name, description=description, annotations=annotations)
+            return fn
+
+        return decorator
 
     def sse_app(self, mount_path: str | None = None) -> Starlette:
         app = super().sse_app(mount_path=mount_path)

--- a/tests/test_namespacing.py
+++ b/tests/test_namespacing.py
@@ -1,0 +1,194 @@
+"""
+Test cases for tool namespacing functionality in NorthMCPServer.
+"""
+
+import pytest
+from north_mcp_python_sdk import NorthMCPServer, _normalize_namespace
+
+
+class TestNamespaceNormalization:
+    """Test the namespace normalization function."""
+    
+    def test_simple_name(self):
+        """Test simple name normalization."""
+        assert _normalize_namespace("Demo") == "demo"
+        assert _normalize_namespace("Calculator") == "calculator"
+    
+    def test_name_with_spaces(self):
+        """Test name with spaces."""
+        assert _normalize_namespace("Slack Dev") == "slack_dev"
+        assert _normalize_namespace("My Server") == "my_server"
+        assert _normalize_namespace("Basic Calculator") == "basic_calculator"
+    
+    def test_name_with_special_chars(self):
+        """Test name with special characters."""
+        assert _normalize_namespace("My-Server") == "my_server"
+        assert _normalize_namespace("Calculator 2.0!") == "calculator_2_0"
+        assert _normalize_namespace("API@Server#1") == "api_server_1"
+    
+    def test_name_with_multiple_separators(self):
+        """Test name with multiple consecutive separators."""
+        assert _normalize_namespace("My---Server") == "my_server"
+        assert _normalize_namespace("Test   Space") == "test_space"
+        assert _normalize_namespace("Multi___Under") == "multi_under"
+    
+    def test_edge_cases(self):
+        """Test edge cases."""
+        assert _normalize_namespace("123") == "123"
+        assert _normalize_namespace("___") == "server"
+        assert _normalize_namespace("") == "server"
+        assert _normalize_namespace("   ") == "server"
+        assert _normalize_namespace("!@#$%") == "server"
+
+
+class TestNorthMCPServerNamespacing:
+    """Test the namespacing functionality in NorthMCPServer."""
+    
+    def test_namespace_enabled_by_default(self):
+        """Test that namespacing is enabled by default."""
+        server = NorthMCPServer("Test Server")
+        assert server._namespace_enabled is True
+        assert server._namespace_prefix == "test_server"
+    
+    def test_namespace_disabled(self):
+        """Test that namespacing can be disabled."""
+        server = NorthMCPServer("Test Server", namespace=False)
+        assert server._namespace_enabled is False
+        assert server._namespace_prefix is None
+    
+    def test_namespace_with_none_name(self):
+        """Test namespacing when server name is None."""
+        server = NorthMCPServer(None, namespace=True)
+        assert server._namespace_enabled is True
+        assert server._namespace_prefix is None
+    
+    def test_get_namespaced_tool_name(self):
+        """Test the internal method for getting namespaced tool names."""
+        server = NorthMCPServer("Demo", namespace=True)
+        assert server._get_namespaced_tool_name("add") == "demo_add"
+        assert server._get_namespaced_tool_name("calculate") == "demo_calculate"
+    
+    def test_get_namespaced_tool_name_disabled(self):
+        """Test tool name when namespacing is disabled."""
+        server = NorthMCPServer("Demo", namespace=False)
+        assert server._get_namespaced_tool_name("add") == "add"
+        assert server._get_namespaced_tool_name("calculate") == "calculate"
+    
+    def test_add_tool_with_namespace(self):
+        """Test adding tools with namespacing enabled."""
+        server = NorthMCPServer("Calculator", namespace=True)
+        
+        def add_func(a: int, b: int) -> int:
+            return a + b
+        
+        def multiply_func(a: int, b: int) -> int:
+            return a * b
+        
+        server.add_tool(add_func)
+        server.add_tool(multiply_func, name="custom_multiply")
+        
+        # Check that tools are registered with namespaced names
+        tools = server._tool_manager.list_tools()
+        tool_names = [tool.name for tool in tools]
+        
+        assert "calculator_add_func" in tool_names
+        assert "calculator_custom_multiply" in tool_names
+    
+    def test_add_tool_without_namespace(self):
+        """Test adding tools with namespacing disabled."""
+        server = NorthMCPServer("Calculator", namespace=False)
+        
+        def add_func(a: int, b: int) -> int:
+            return a + b
+        
+        def multiply_func(a: int, b: int) -> int:
+            return a * b
+        
+        server.add_tool(add_func)
+        server.add_tool(multiply_func, name="custom_multiply")
+        
+        # Check that tools are registered without namespaced names
+        tools = server._tool_manager.list_tools()
+        tool_names = [tool.name for tool in tools]
+        
+        assert "add_func" in tool_names
+        assert "custom_multiply" in tool_names
+    
+    def test_tool_decorator_with_namespace(self):
+        """Test the @tool decorator with namespacing enabled."""
+        server = NorthMCPServer("Math Server", namespace=True)
+        
+        @server.tool()
+        def subtract(a: int, b: int) -> int:
+            """Subtract b from a"""
+            return a - b
+        
+        @server.tool(name="divide_numbers")
+        def divide(a: float, b: float) -> float:
+            """Divide a by b"""
+            return a / b
+        
+        # Check that tools are registered with namespaced names
+        tools = server._tool_manager.list_tools()
+        tool_names = [tool.name for tool in tools]
+        
+        assert "math_server_subtract" in tool_names
+        assert "math_server_divide_numbers" in tool_names
+    
+    def test_tool_decorator_without_namespace(self):
+        """Test the @tool decorator with namespacing disabled."""
+        server = NorthMCPServer("Math Server", namespace=False)
+        
+        @server.tool()
+        def subtract(a: int, b: int) -> int:
+            """Subtract b from a"""
+            return a - b
+        
+        @server.tool(name="divide_numbers")
+        def divide(a: float, b: float) -> float:
+            """Divide a by b"""
+            return a / b
+        
+        # Check that tools are registered without namespaced names
+        tools = server._tool_manager.list_tools()
+        tool_names = [tool.name for tool in tools]
+        
+        assert "subtract" in tool_names
+        assert "divide_numbers" in tool_names
+    
+    def test_multiple_servers_different_namespaces(self):
+        """Test that multiple servers with different namespaces work independently."""
+        calc_server = NorthMCPServer("Calculator", namespace=True)
+        slack_server = NorthMCPServer("Slack Dev", namespace=True)
+        
+        @calc_server.tool()
+        def add(a: int, b: int) -> int:
+            return a + b
+        
+        @slack_server.tool()
+        def add(channel: str, message: str) -> str:
+            return f"Added message to {channel}: {message}"
+        
+        # Check calculator server tools
+        calc_tools = calc_server._tool_manager.list_tools()
+        calc_tool_names = [tool.name for tool in calc_tools]
+        assert "calculator_add" in calc_tool_names
+        
+        # Check slack server tools
+        slack_tools = slack_server._tool_manager.list_tools()
+        slack_tool_names = [tool.name for tool in slack_tools]
+        assert "slack_dev_add" in slack_tool_names
+        
+        # Ensure no cross-contamination
+        assert "slack_dev_add" not in calc_tool_names
+        assert "calculator_add" not in slack_tool_names
+    
+    def test_tool_decorator_error_handling(self):
+        """Test that the tool decorator handles errors correctly."""
+        server = NorthMCPServer("Test", namespace=True)
+        
+        # Test incorrect usage (passing function directly)
+        with pytest.raises(TypeError, match="The @tool decorator was used incorrectly"):
+            @server.tool  # Missing parentheses
+            def bad_tool():
+                pass


### PR DESCRIPTION
Currently, registering MCP servers that have the same tool name will cause issues for MCP clients. We want to enable uniqueness across MCP servers, thus introduce basic namespacing to tool names based on the `name` of the `NorthMCPServer`