### PR TITLE
fix: add auth middleware protected route for /messages endpoint for sse servers

### DIFF
--- a/tests/test_custom_routes.py
+++ b/tests/test_custom_routes.py
@@ -164,6 +164,42 @@ async def test_sse_routes_require_auth(sse_test_client):
 
 
 @pytest.mark.asyncio
+async def test_messages_routes_require_auth(sse_test_client):
+    """Test that /messages/* routes require authentication."""
+    response = await sse_test_client.post("/messages/test-session-id", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "test",
+        "params": {}
+    })
+    assert response.status_code == 401
+    
+    headers = {"Authorization": "Bearer invalid"}
+    response = await sse_test_client.post("/messages/test-session-id", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "test", 
+        "params": {}
+    }, headers=headers)
+    assert response.status_code == 401
+    
+    test_paths = [
+        "/messages/",
+        "/messages/abc-123",
+        "/messages/session-uuid-here"
+    ]
+    
+    for path in test_paths:
+        response = await sse_test_client.post(path, json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "test",
+            "params": {}
+        })
+        assert response.status_code == 401, f"Path {path} should require auth but returned {response.status_code}"
+
+
+@pytest.mark.asyncio
 async def test_custom_routes_with_optional_auth(test_client):
     """Test that custom routes can optionally use auth info."""
     # Test auth-info endpoint with auth


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the NorthAuthenticationMiddleware class to include authentication for the /messages/* endpoint, adding a new test case to verify that these routes require authentication.

- Updates the docstring for the NorthAuthenticationMiddleware class to include /messages/* as an authenticated endpoint.
- Modifies the _should_authenticate method to check for paths starting with /messages/ and mark them as requiring authentication.
- Adds a new test case, test_messages_routes_require_auth, to verify that /messages/* routes require authentication.
- The test case checks multiple paths under /messages/ and asserts that they all return a 401 status code when accessed without authentication.

<!-- end-generated-description -->