### PR TITLE
chore: add CI tests as gate before merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a GitHub Actions workflow file to the `.github/workflows` directory.

- The workflow is triggered on pushes and pull requests to the `main` branch.
- It defines a single job called `test` that runs on the `ubuntu-latest` runner.
- The job uses a matrix strategy to test against Python versions 3.11 and 3.12.
- The job steps include:
  - Checking out the code
  - Installing `uv` using the `astral-sh/setup-uv` action
  - Setting up the specified Python version using `uv python install`
  - Installing dependencies using `uv sync --dev`
  - Running tests using `uv run pytest`

<!-- end-generated-description -->