### PR TITLE
fix: normalize trailing slash for protected routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.2.1"
+version = "0.2.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -75,9 +75,11 @@ class NorthAuthenticationMiddleware(AuthenticationMiddleware):
         Check if the given path requires authentication.
         Only MCP protocol paths (/mcp, /sse, /messages/*) require auth by default.
         """
-
-        if path in self.protected_paths:
-            return True
+        normalized_path = path.rstrip('/')
+        for protected_path in self.protected_paths:
+            # Check both with and without trailing slash
+            if normalized_path == protected_path.rstrip('/'):
+                return True
         
         # for SSE servers
         if path.startswith("/messages/"):

--- a/tests/test_custom_routes.py
+++ b/tests/test_custom_routes.py
@@ -136,6 +136,14 @@ async def test_mcp_routes_require_auth(test_client):
     })
     assert response.status_code == 401
     
+    response = await test_client.post("/mcp/", json={
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    })
+    assert response.status_code == 401
+    
     # Test MCP endpoint with auth (should work)
     headers = {"Authorization": create_auth_header()}
     response = await test_client.post("/mcp", json={


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the version of the project and makes changes to the authentication process and testing of the MCP routes.

- The project version has been updated from 0.2.1 to 0.2.2.
- The authentication process has been updated to normalise the path and check for protected paths with and without trailing slashes.
- The testing of MCP routes has been updated to include a test for the /mcp/ endpoint without authentication.

<!-- end-generated-description -->