### PR TITLE
ci: tag releases using pyproject version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -32,3 +35,36 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  tag_release:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          version = data["project"]["version"]
+          print(f"version={version}")
+          with open("$GITHUB_OUTPUT", "a") as fh:
+              fh.write(f"version={version}\n")
+          PY
+
+      - name: Create tag if missing
+        run: |
+          tag="${{ steps.version.outputs.version }}"
+          if git tag --list "$tag" | grep -q "$tag"; then
+            echo "Tag $tag already exists. Skipping."
+            exit 0
+          fi
+          git tag "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a new tag_release job to the .github/workflows/ci.yml file. This job is responsible for creating a new Git tag based on the version specified in the pyproject.toml file.

- Adds a new permissions section to the workflow file, granting write access to the repository contents.
- Introduces a new tag_release job that runs on ubuntu-latest and depends on the successful completion of the test job.
- The job only runs when a push event occurs on the main branch.
- The Determine version step reads the version from the pyproject.toml file using Python and sets it as an output variable.
- The Create tag if missing step checks if a tag with the determined version already exists. If not, it creates a new tag and pushes it to the remote repository.

<!-- end-generated-description -->