### PR TITLE
Updated check for north headers to ensure values are non-empty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.2.4"
+version = "0.2.5"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -229,7 +229,7 @@ class NorthAuthBackend(AuthenticationBackend):
             return tokens
         except Exception as e:
             self.logger.debug("Failed to parse connector tokens: %s", e)
-            raise AuthenticationError("invalid connector tokens format")
+            return {}
 
     def _validate_server_secret(self, provided_secret: str | None) -> None:
         """Validate server secret matches expected value."""
@@ -285,10 +285,22 @@ class NorthAuthBackend(AuthenticationBackend):
         self.logger.debug("Using X-North headers for authentication")
 
         # Extract headers
+        # Auth Headers
         user_id_token = conn.headers.get("X-North-ID-Token")
-        user_email_header = conn.headers.get("X-North-User-Email")
-        connector_tokens_header = conn.headers.get("X-North-Connector-Tokens")
         server_secret = conn.headers.get("X-North-Server-Secret")
+
+        if not user_id_token and not server_secret:
+            self.logger.debug("No X-North-ID-Token or X-North-Server-Secret header present")
+            raise AuthenticationError("no authentication headers present")
+
+        self._validate_server_secret(server_secret)
+        token_email = self._process_user_id_token(user_id_token)
+
+        self.logger.debug("X-North authentication successful")
+
+        # Additional Headers
+        connector_tokens_header = conn.headers.get("X-North-Connector-Tokens")
+        user_email_header = conn.headers.get("X-North-User-Email")
 
         # Parse connector tokens (Base64 URL-safe encoded JSON)
         connector_access_tokens = {}
@@ -296,6 +308,10 @@ class NorthAuthBackend(AuthenticationBackend):
             connector_access_tokens = self._parse_connector_tokens(
                 connector_tokens_header
             )
+
+        email = token_email
+        if token_email is None and user_email_header:
+            email = user_email_header
 
         self.logger.debug(
             "X-North headers parsed. Has server_secret: %s, Has user_id_token: %s, Connector count: %d",
@@ -307,12 +323,6 @@ class NorthAuthBackend(AuthenticationBackend):
             "Available connectors: %s", list(connector_access_tokens.keys())
         )
 
-        self._validate_server_secret(server_secret)
-        email = self._process_user_id_token(user_id_token)
-        if email is None and user_email_header:
-            email = user_email_header
-
-        self.logger.debug("X-North authentication successful")
         return self._create_authenticated_user(email, connector_access_tokens)
 
     async def _authenticate_legacy_bearer(

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -209,7 +209,7 @@ class NorthAuthBackend(AuthenticationBackend):
     def _has_x_north_headers(self, conn: HTTPConnection) -> bool:
         """Check if any X-North headers are present."""
         return any(
-            header in conn.headers and conn.headers[header] != ""
+            header in conn.headers and conn.headers[header].strip() != ""
             for header in [
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",
@@ -233,7 +233,7 @@ class NorthAuthBackend(AuthenticationBackend):
 
     def _validate_server_secret(self, provided_secret: str | None) -> None:
         """Validate server secret matches expected value."""
-        if self._server_secret and self._server_secret != provided_secret:
+        if (self._server_secret and self._server_secret != provided_secret) or (not self._server_secret and provided_secret):
             self.logger.debug("Server secret mismatch - access denied")
             raise AuthenticationError("access denied")
 

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -209,7 +209,7 @@ class NorthAuthBackend(AuthenticationBackend):
     def _has_x_north_headers(self, conn: HTTPConnection) -> bool:
         """Check if any X-North headers are present."""
         return any(
-            header in conn.headers
+            header in conn.headers and conn.headers[header] != ""
             for header in [
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -228,7 +228,7 @@ class NorthAuthBackend(AuthenticationBackend):
                 raise ValueError("Connector tokens must be a JSON object")
             return tokens
         except Exception as e:
-            self.logger.debug("Failed to parse connector tokens: %s", e)
+            self.logger.warning("Failed to parse connector tokens: %s", e)
             return {}
 
     def _validate_server_secret(self, provided_secret: str | None) -> None:


### PR DESCRIPTION
Below are some examples of the issues this PR aims to fix. In summary the previous check allowed for empty headers to trigger a north header auth check. This _would_ be ok (although not desired) if empty values were handled correctly, but instead empty values allows check to be skipped.

# Issue 1
Resolve potential authentication bypass triggered by sending empty values within north headers.

Trigger: `curl -v -X POST http://localhost:3001/mcp -H "x-north-server-secret;"` (any of the north headers can trigger this)

Before hotfix:
```
INFO:     Uvicorn running on http://0.0.0.0:3001 (Press CTRL+C to quit)
Path /mcp is an MCP protocol endpoint, applying authentication
Authenticating request from Address(host='127.0.0.1', port=49331)
Request headers: {'host': 'localhost:3001', 'user-agent': 'curl/8.7.1', 'accept': '*/*', 'x-north-server-secret': ''}
Using X-North headers for authentication
X-North headers parsed. Has server_secret: True, Has user_id_token: False, Connector count: 0
Available connectors: []
X-North authentication successful
Setting authenticated user in context: email=None, connectors=[]
INFO:     127.0.0.1:49331 - "POST /mcp HTTP/1.1" 307 Temporary Redirect
```

After hotfix:
```
INFO:     Uvicorn running on http://0.0.0.0:3001 (Press CTRL+C to quit)
Path /mcp is an MCP protocol endpoint, applying authentication
Authenticating request from Address(host='127.0.0.1', port=49483)
Request headers: {'host': 'localhost:3001', 'user-agent': 'curl/8.7.1', 'accept': '*/*', 'x-north-server-secret': ''}
Using legacy Authorization Bearer header for authentication
No Authorization header present
INFO:     127.0.0.1:49483 - "POST /mcp HTTP/1.1" 401 Unauthorized
```

# Issue 2
Providing any server secret when there was not one set on MCP server bypasses auth check.

Before hotfix:
```
INFO:     Uvicorn running on http://0.0.0.0:3001 (Press CTRL+C to quit)
Path /mcp is an MCP protocol endpoint, applying authentication
Authenticating request from Address(host='127.0.0.1', port=51255)
Request headers: {'host': 'localhost:3001', 'user-agent': 'curl/8.7.1', 'accept': '*/*', 'x-north-server-secret': '12345'}
Using X-North headers for authentication
X-North headers parsed. Has server_secret: True, Has user_id_token: False, Connector count: 0
Available connectors: []
X-North authentication successful
Setting authenticated user in context: email=None, connectors=[]
INFO:     127.0.0.1:51255 - "POST /mcp HTTP/1.1" 307 Temporary Redirect
```

After hotfix:
```
INFO:     Uvicorn running on http://0.0.0.0:3001 (Press CTRL+C to quit)
Path /mcp is an MCP protocol endpoint, applying authentication
Authenticating request from Address(host='127.0.0.1', port=51409)
Request headers: {'host': 'localhost:3001', 'user-agent': 'curl/8.7.1', 'accept': '*/*', 'x-north-server-secret': '12345'}
Using X-North headers for authentication
X-North headers parsed. Has server_secret: True, Has user_id_token: False, Connector count: 0
Available connectors: []
Server secret mismatch - access denied
INFO:     127.0.0.1:51409 - "POST /mcp HTTP/1.1" 401 Unauthorized
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches request authentication gating and server-secret validation; mistakes could inadvertently allow/deny access for MCP endpoints.
> 
> **Overview**
> Tightens `NorthAuthBackend` authentication to avoid treating *present-but-empty* `X-North-*` headers as valid, preventing accidental routing into the X-North auth path.
> 
> Fixes two bypass vectors: rejects requests that provide a `X-North-Server-Secret` when no server secret is configured, and requires at least one non-empty auth header (`X-North-ID-Token` or `X-North-Server-Secret`) before accepting X-North header auth.
> 
> Makes malformed `X-North-Connector-Tokens` non-fatal by logging and ignoring them (returns `{}`) instead of failing the request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a288d65dbd159a196e659f487d41b456c26c0eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->