### PR TITLE
v0.2.5 -> v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.2.5"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]
 requires-python = ">=3.11"
 dependencies = [
- "fastmcp>=2.14.5",
+ "fastmcp>=2.14.5,<3",
  "pyjwt[crypto]>=2.10.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -857,7 +857,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", specifier = ">=2.14.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
 ]
 


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only packaging metadata changes (version bump and dependency pin); no runtime code changes, with minimal risk beyond potential dependency resolution differences.
> 
> **Overview**
> Bumps the `north-mcp-python-sdk` package version from `0.2.5` to `0.3.0`.
> 
> Tightens the `fastmcp` dependency constraint to `>=2.14.5,<3` (and updates `uv.lock` metadata accordingly) to prevent installs against the v3 major release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5efa314609804ebec231acc2e04d1a981439674b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->