### PR TITLE
Create v0.3.1

### DIFF
--- a/examples/auth-provider-local-mcp/uv.lock
+++ b/examples/auth-provider-local-mcp/uv.lock
@@ -706,7 +706,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.2.5"
+version = "0.3.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "fastmcp" },
@@ -715,7 +715,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", specifier = ">=2.14.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.2.5"
+version = "0.3.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]
 requires-python = ">=3.11"
 dependencies = [
- "fastmcp>=2.14.5",
+ "fastmcp>=2.14.5,<3",
  "pyjwt[crypto]>=2.10.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.2.5"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -857,7 +857,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", specifier = ">=2.14.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
 ]
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the version of the north-mcp-python-sdk from 0.2.5 to 0.3.1 and adjusts the fastmcp dependency to exclude versions 3 and above.

- The version of the north-mcp-python-sdk has been updated from 0.2.5 to 0.3.1 in both the pyproject.toml and uv.lock files.
- The fastmcp dependency has been adjusted to exclude versions 3 and above in both the pyproject.toml and uv.lock files.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 83e526132000451139e73e2930870e7671062a63. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->