### PR TITLE
fix(auth): accept connector token context without ID token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.4.2"
+version = "0.4.3"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -231,6 +231,7 @@ class NorthAuthBackend(AuthenticationBackend):
             for header in [
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",
+                "X-North-User-Email",
             ]
         )
 
@@ -341,24 +342,26 @@ class NorthAuthBackend(AuthenticationBackend):
         )
 
     async def _authenticate_x_north_headers(
-        self, conn: HTTPConnection
+        self, conn: HTTPConnection, *, require_id_token: bool = True
     ) -> tuple[AuthCredentials, BaseUser]:
         """Authenticate using new X-North headers."""
         self.logger.debug("Using X-North headers for authentication")
 
         user_id_token = conn.headers.get("X-North-ID-Token")
+        user_email_header = conn.headers.get("X-North-User-Email")
 
         if not user_id_token:
             self.logger.debug("No X-North-ID-Token header present")
-            raise AuthenticationError("no authentication headers present")
-
-        token_email = self._process_user_id_token(user_id_token)
+            if require_id_token:
+                raise AuthenticationError("no authentication headers present")
+            token_email = None
+        else:
+            token_email = self._process_user_id_token(user_id_token)
 
         self.logger.debug("X-North authentication successful")
 
         # Additional Headers
         connector_tokens_header = conn.headers.get("X-North-Connector-Tokens")
-        user_email_header = conn.headers.get("X-North-User-Email")
 
         # Parse connector tokens (Base64 URL-safe encoded JSON)
         connector_access_tokens = {}
@@ -455,7 +458,9 @@ class NorthAuthBackend(AuthenticationBackend):
                 self.logger.debug(
                     "No auth configured, but X-North headers are present; parsing request context without enforcing authentication"
                 )
-                return await self._authenticate_x_north_headers(conn)
+                return await self._authenticate_x_north_headers(
+                    conn, require_id_token=False
+                )
 
             if conn.headers.get("Authorization"):
                 self.logger.debug(

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -209,6 +209,36 @@ async def test_x_north_user_email_header_fallback():
 
 
 @pytest.mark.asyncio
+async def test_x_north_connector_tokens_without_id_token_open_auth():
+    """Test connector tokens can provide context without an ID token in open auth mode."""
+    backend = NorthAuthBackend()
+
+    connector_tokens_json = json.dumps({"github": "token123"})
+    connector_tokens_b64 = (
+        base64.urlsafe_b64encode(connector_tokens_json.encode())
+        .decode()
+        .rstrip("=")
+    )
+    headers = {
+        "X-North-Connector-Tokens": connector_tokens_b64,
+        "X-North-User-Email": "fallback@company.com",
+    }
+    conn = create_mock_connection(headers)
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.token == ""
+    assert user.access_token.claims["email"] == "fallback@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "github": "token123"
+    }
+
+
+@pytest.mark.asyncio
 async def test_x_north_user_email_header_not_override_token_email():
     """Test that ID token email takes precedence over X-North-User-Email."""
     backend = NorthAuthBackend()

--- a/tests/test_x_north_trusted_issuers.py
+++ b/tests/test_x_north_trusted_issuers.py
@@ -116,6 +116,30 @@ async def test_trusted_issuers_require_auth_headers():
 
 
 @pytest.mark.asyncio
+async def test_trusted_issuers_reject_connector_tokens_without_id_token():
+    backend = NorthAuthBackend(
+        trusted_issuers=["https://example.okta.com"],
+    )
+    connector_tokens_json = json.dumps({"github": "token123"})
+    connector_tokens_b64 = (
+        base64.urlsafe_b64encode(connector_tokens_json.encode())
+        .decode()
+        .rstrip("=")
+    )
+    conn = create_mock_connection(
+        {
+            "X-North-Connector-Tokens": connector_tokens_b64,
+            "X-North-User-Email": "fallback@company.com",
+        }
+    )
+
+    with pytest.raises(
+        AuthenticationError, match="no authentication headers present"
+    ):
+        await backend.authenticate(conn)
+
+
+@pytest.mark.asyncio
 async def test_x_north_headers_trusted_issuers_missing_issuer():
     """Test X-North headers reject tokens missing issuer when trusted issuers configured."""
     backend = NorthAuthBackend(

--- a/uv.lock
+++ b/uv.lock
@@ -767,7 +767,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What changed
- Allows open MCP auth mode to parse X-North connector token context even when `X-North-ID-Token` is absent.
- Keeps `X-North-ID-Token` required when `trusted_issuers` are configured.
- Bumps the SDK package version to `0.4.3` for downstream MCP server consumption.

## Context
North can send connector tokens for an MCP request without also sending an ID token when the effective user does not resolve to a Dex ID token. After server-secret support was removed, that request shape caused the SDK to enter the X-North auth path and then reject the request because it still required `X-North-ID-Token`.

For open/internal MCP servers without `trusted_issuers`, the middleware is acting as a North request-context parser rather than enforcing cryptographic ID-token auth. This keeps strict behavior for configured issuers while allowing connector-token-backed tools to receive their context.

## How to verify
- `uv run pytest tests/test_x_north_auth_backend.py tests/test_x_north_trusted_issuers.py`
- `uv run ruff check src/north_mcp_python_sdk/auth.py tests/test_x_north_auth_backend.py tests/test_x_north_trusted_issuers.py`

## Reviewer focus
- The `require_id_token=False` path is only used when no auth is configured; servers with `trusted_issuers` still reject connector-token-only requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes authentication requirements on the open-auth path only, but still allows unverified connector/email context to reach tools—appropriate for internal parsers but worth confirming deployment assumptions.
> 
> **Overview**
> Fixes North MCP requests that ship **connector tokens** (and optional `X-North-User-Email`) **without** `X-North-ID-Token`, which were failing after server-secret auth was removed.
> 
> In **open auth** (no `trusted_issuers`), the backend now parses X-North context with `require_id_token=False`, building an `AuthenticatedUser` with empty ID token, fallback email, and parsed connector tokens. **`X-North-User-Email` alone** also counts as an X-North header for this path.
> 
> When **`trusted_issuers` are set**, behavior is unchanged: **`X-North-ID-Token` is still required**; connector-token-only requests still raise `no authentication headers present`.
> 
> Package version is bumped to **0.4.3** (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b71c8dc95630d5f026d5c7b43ab5716a6888dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->