### PR TITLE
fix: backport MCP auth compatibility to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.3.3"
+version = "0.3.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -38,7 +38,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 class AuthHeaderTokens(BaseModel):
-    server_secret: str | None
+    server_secret: str | None = None
     user_id_token: str | None
     connector_access_tokens: dict[str, str] = Field(default_factory=dict)
 

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -236,7 +236,6 @@ class NorthAuthBackend(AuthenticationBackend):
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",
                 "X-North-Server-Secret",
-                "X-North-User-Email",
             ]
         )
 

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -236,6 +236,7 @@ class NorthAuthBackend(AuthenticationBackend):
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",
                 "X-North-Server-Secret",
+                "X-North-User-Email",
             ]
         )
 
@@ -277,7 +278,12 @@ class NorthAuthBackend(AuthenticationBackend):
     def _auth_is_configured(self) -> bool:
         return bool(self._server_secret or self._trusted_issuers)
 
-    def _validate_server_secret(self, provided_secret: str | None) -> None:
+    def _validate_server_secret(
+        self,
+        provided_secret: str | None,
+        *,
+        allow_missing_with_user_auth: bool = False,
+    ) -> None:
         """Validate server secret matches expected value."""
         if provided_secret:
             warn(
@@ -285,9 +291,20 @@ class NorthAuthBackend(AuthenticationBackend):
                 DeprecationWarning,
             )
 
-        if (
-            self._server_secret and self._server_secret != provided_secret
-        ) or (not self._server_secret and provided_secret):
+        if self._server_secret and not provided_secret:
+            if allow_missing_with_user_auth:
+                self.logger.debug(
+                    "Server secret missing, allowing request with user authentication"
+                )
+                return
+            self.logger.debug("Server secret missing - access denied")
+            raise AuthenticationError("access denied")
+
+        if self._server_secret and self._server_secret != provided_secret:
+            self.logger.debug("Server secret mismatch - access denied")
+            raise AuthenticationError("access denied")
+
+        if not self._server_secret and provided_secret:
             self.logger.debug("Server secret mismatch - access denied")
             raise AuthenticationError("access denied")
 
@@ -360,7 +377,7 @@ class NorthAuthBackend(AuthenticationBackend):
         )
 
     async def _authenticate_x_north_headers(
-        self, conn: HTTPConnection
+        self, conn: HTTPConnection, *, require_auth_material: bool = True
     ) -> tuple[AuthCredentials, BaseUser]:
         """Authenticate using new X-North headers."""
         self.logger.debug("Using X-North headers for authentication")
@@ -374,9 +391,13 @@ class NorthAuthBackend(AuthenticationBackend):
             self.logger.debug(
                 "No X-North-ID-Token or X-North-Server-Secret header present"
             )
-            raise AuthenticationError("no authentication headers present")
+            if require_auth_material:
+                raise AuthenticationError("no authentication headers present")
 
-        self._validate_server_secret(server_secret)
+        self._validate_server_secret(
+            server_secret,
+            allow_missing_with_user_auth=bool(user_id_token),
+        )
         token_email = self._process_user_id_token(user_id_token)
 
         self.logger.debug("X-North authentication successful")
@@ -457,7 +478,10 @@ class NorthAuthBackend(AuthenticationBackend):
             self.logger.debug("Failed to validate auth tokens: %s", e)
             raise AuthenticationError("unable to decode bearer token")
 
-        self._validate_server_secret(tokens.server_secret)
+        self._validate_server_secret(
+            tokens.server_secret,
+            allow_missing_with_user_auth=bool(tokens.user_id_token),
+        )
         email = self._process_user_id_token(tokens.user_id_token)
 
         self.logger.debug("Legacy authentication successful")
@@ -479,7 +503,9 @@ class NorthAuthBackend(AuthenticationBackend):
                 self.logger.debug(
                     "No auth configured, but X-North headers are present; parsing request context without enforcing authentication"
                 )
-                return await self._authenticate_x_north_headers(conn)
+                return await self._authenticate_x_north_headers(
+                    conn, require_auth_material=False
+                )
 
             if conn.headers.get("Authorization"):
                 self.logger.debug(

--- a/tests/test_north_mcp_server.py
+++ b/tests/test_north_mcp_server.py
@@ -95,7 +95,7 @@ async def test_invalid_base64_auth_header(
 
 
 @pytest.mark.asyncio
-async def test_missing_server_secret():
+async def test_missing_server_secret_allows_user_auth():
     server = NorthMCPServer(server_secret="secret")
     asgi_app = server.http_app(transport="streamable-http")
 
@@ -120,7 +120,7 @@ async def test_missing_server_secret():
                 headers={"Authorization": f"Bearer {header_as_b64}"},
             )
 
-            assert result.status_code == 401, result.text
+            assert result.status_code != 401, result.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_north_token_verifier.py
+++ b/tests/test_north_token_verifier.py
@@ -218,8 +218,7 @@ class TestNorthTokenVerifierIntegration:
 
     @pytest.mark.asyncio
     async def test_server_secret_validation(self, fastmcp_with_secret):
-        """Test that server secret is validated."""
-        # Without secret - should fail
+        """Test that user auth works when server secret is absent."""
         auth_header = self.create_auth_header(server_secret=None)
         response = await fastmcp_with_secret.post(
             "/mcp",
@@ -231,7 +230,7 @@ class TestNorthTokenVerifierIntegration:
                 "params": {},
             },
         )
-        assert response.status_code == 401
+        assert response.status_code != 401
 
     @pytest.mark.asyncio
     async def test_server_secret_auth_requires_headers(

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -177,6 +177,43 @@ async def test_legacy_bearer_fallback():
 
 
 @pytest.mark.asyncio
+async def test_legacy_bearer_fallback_with_user_email_context_header():
+    """Test X-North-User-Email alone does not block legacy bearer auth."""
+    from north_mcp_python_sdk.auth import AuthHeaderTokens
+
+    backend = NorthAuthBackend(server_secret="server_secret")
+
+    user_token = jwt.encode(
+        payload={"email": "legacy@company.com"}, key="test"
+    )
+    legacy_header = AuthHeaderTokens(
+        server_secret="server_secret",
+        user_id_token=user_token,
+        connector_access_tokens={"legacy": "legacy_token"},
+    )
+    legacy_b64 = base64.b64encode(
+        json.dumps(legacy_header.model_dump()).encode()
+    ).decode()
+
+    headers = {
+        "Authorization": f"Bearer {legacy_b64}",
+        "X-North-User-Email": "context@company.com",
+    }
+    conn = create_mock_connection(headers)
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.claims["email"] == "legacy@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "legacy": "legacy_token"
+    }
+
+
+@pytest.mark.asyncio
 async def test_minimal_x_north_headers():
     """Test X-North with minimal headers (just server secret)."""
     backend = NorthAuthBackend(server_secret="server_secret")
@@ -291,7 +328,7 @@ async def test_x_north_server_secret_still_required_without_user_auth():
     conn = create_mock_connection({"X-North-User-Email": "email@company.com"})
 
     with pytest.raises(
-        AuthenticationError, match="no authentication headers present"
+        AuthenticationError, match="invalid authorization header"
     ):
         await backend.authenticate(conn)
 

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -330,6 +330,34 @@ async def test_legacy_bearer_id_token_allowed_when_server_secret_missing():
 
 
 @pytest.mark.asyncio
+async def test_legacy_bearer_id_token_allowed_when_server_secret_key_omitted():
+    """Test latest North legacy bundle shape works without server_secret key."""
+    backend = NorthAuthBackend(server_secret="server_secret")
+
+    user_id_token = jwt.encode(
+        payload={"email": "legacy@company.com"}, key="test"
+    )
+    legacy_header = {
+        "user_id_token": user_id_token,
+        "connector_access_tokens": {"legacy": "legacy_token"},
+    }
+    legacy_b64 = base64.b64encode(json.dumps(legacy_header).encode()).decode()
+
+    conn = create_mock_connection({"Authorization": f"Bearer {legacy_b64}"})
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.claims["email"] == "legacy@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "legacy": "legacy_token"
+    }
+
+
+@pytest.mark.asyncio
 async def test_x_north_connector_tokens_without_id_token_open_auth():
     """Test connector tokens can provide context without an ID token in open auth mode."""
     backend = NorthAuthBackend()

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -264,6 +264,102 @@ async def test_x_north_user_email_with_server_secret_only():
 
 
 @pytest.mark.asyncio
+async def test_x_north_id_token_allowed_when_server_secret_missing():
+    """Test configured server secret does not block valid user-auth requests."""
+    backend = NorthAuthBackend(server_secret="server_secret")
+
+    user_id_token = jwt.encode(
+        payload={"email": "test@company.com"}, key="test"
+    )
+    headers = {"X-North-ID-Token": user_id_token}
+    conn = create_mock_connection(headers)
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.claims["email"] == "test@company.com"
+
+
+@pytest.mark.asyncio
+async def test_x_north_server_secret_still_required_without_user_auth():
+    """Test configured server secret still protects requests without user auth."""
+    backend = NorthAuthBackend(server_secret="server_secret")
+
+    conn = create_mock_connection({"X-North-User-Email": "email@company.com"})
+
+    with pytest.raises(
+        AuthenticationError, match="no authentication headers present"
+    ):
+        await backend.authenticate(conn)
+
+
+@pytest.mark.asyncio
+async def test_legacy_bearer_id_token_allowed_when_server_secret_missing():
+    """Test legacy bearer can use user auth without sending server secret."""
+    from north_mcp_python_sdk.auth import AuthHeaderTokens
+
+    backend = NorthAuthBackend(server_secret="server_secret")
+
+    user_id_token = jwt.encode(
+        payload={"email": "legacy@company.com"}, key="test"
+    )
+    legacy_header = AuthHeaderTokens(
+        server_secret=None,
+        user_id_token=user_id_token,
+        connector_access_tokens={"legacy": "legacy_token"},
+    )
+    legacy_b64 = base64.b64encode(
+        json.dumps(legacy_header.model_dump()).encode()
+    ).decode()
+
+    conn = create_mock_connection({"Authorization": f"Bearer {legacy_b64}"})
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.claims["email"] == "legacy@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "legacy": "legacy_token"
+    }
+
+
+@pytest.mark.asyncio
+async def test_x_north_connector_tokens_without_id_token_open_auth():
+    """Test connector tokens can provide context without an ID token in open auth mode."""
+    backend = NorthAuthBackend()
+
+    connector_tokens_json = json.dumps({"github": "token123"})
+    connector_tokens_b64 = (
+        base64.urlsafe_b64encode(connector_tokens_json.encode())
+        .decode()
+        .rstrip("=")
+    )
+    headers = {
+        "X-North-Connector-Tokens": connector_tokens_b64,
+        "X-North-User-Email": "fallback@company.com",
+    }
+    conn = create_mock_connection(headers)
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.token == ""
+    assert user.access_token.claims["email"] == "fallback@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "github": "token123"
+    }
+
+
+@pytest.mark.asyncio
 async def test_x_north_empty_headers_treated_as_absent():
     """Test that empty X-North headers are treated as absent."""
     backend = NorthAuthBackend(server_secret="server_secret")

--- a/tests/test_x_north_trusted_issuers.py
+++ b/tests/test_x_north_trusted_issuers.py
@@ -121,6 +121,30 @@ async def test_trusted_issuers_require_auth_headers():
 
 
 @pytest.mark.asyncio
+async def test_trusted_issuers_reject_connector_tokens_without_id_token():
+    backend = NorthAuthBackend(
+        trusted_issuers=["https://example.okta.com"],
+    )
+    connector_tokens_json = json.dumps({"github": "token123"})
+    connector_tokens_b64 = (
+        base64.urlsafe_b64encode(connector_tokens_json.encode())
+        .decode()
+        .rstrip("=")
+    )
+    conn = create_mock_connection(
+        {
+            "X-North-Connector-Tokens": connector_tokens_b64,
+            "X-North-User-Email": "fallback@company.com",
+        }
+    )
+
+    with pytest.raises(
+        AuthenticationError, match="no authentication headers present"
+    ):
+        await backend.authenticate(conn)
+
+
+@pytest.mark.asyncio
 async def test_x_north_headers_trusted_issuers_missing_issuer():
     """Test X-North headers reject tokens missing issuer when trusted issuers configured."""
     backend = NorthAuthBackend(

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.3.1"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Backports MCP auth compatibility behavior to the `0.3.x` release line.
- Bumps the SDK version to `0.3.4`.
- Keeps server-secret support for old North, while allowing valid user-auth requests from newer North that no longer sends server secrets.
- Allows connector-token/user-email context without an ID token only when auth is not configured.

## Root Cause
North can now call MCP servers without sending `X-North-Server-Secret`. Existing `0.3.x` SDK server-secret validation rejected those requests even when valid user auth was present, which made the line less useful as a transition release.

## Validation
- `uv format --preview-features format --check`
- `uv run pytest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication acceptance rules on MCP routes; behavior is narrower than before for some cases but broadens access when user tokens are present without secrets.
> 
> **Overview**
> Bumps the SDK to **0.3.4** and relaxes **server-secret** checks so newer North clients that send user ID tokens but omit `X-North-Server-Secret` (or legacy bearer bundles without `server_secret`) still authenticate when a server secret is configured. Wrong or unexpected secrets still fail; requests with only context headers (e.g. user email) without user auth remain blocked.
> 
> **`AuthHeaderTokens`** now defaults `server_secret` to `None` so legacy JSON can omit that field. **`_validate_server_secret`** gains `allow_missing_with_user_auth`; X-North and legacy paths enable it when a user ID token is present. In **unconfigured auth** mode, X-North parsing can run with `require_auth_material=False`, allowing connector tokens and user email without an ID token; **trusted issuers** still require real auth material and reject connector-only context.
> 
> Tests are updated and expanded for these flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dda070abfc1549ad4d496ce796f94a84a1aefab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->