### PR TITLE
fix(deps): constrain FastMCP for SDK 0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.4.3"
+version = "0.4.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]
 requires-python = ">=3.11"
 dependencies = [
- "fastmcp>=3.0.0,<4",
+ "fastmcp>=3.0.0,<3.4.3",
  "opentelemetry-api>=1.28.0",
  "pyjwt[crypto]>=2.10.1",
 ]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -231,7 +231,6 @@ class NorthAuthBackend(AuthenticationBackend):
             for header in [
                 "X-North-ID-Token",
                 "X-North-Connector-Tokens",
-                "X-North-User-Email",
             ]
         )
 

--- a/tests/test_custom_routes.py
+++ b/tests/test_custom_routes.py
@@ -10,7 +10,7 @@ import httpx
 import jwt
 from asgi_lifespan import LifespanManager
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.responses import JSONResponse
 
 from north_mcp_python_sdk import NorthMCPServer
 from north_mcp_python_sdk.auth import get_authenticated_user

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -209,6 +209,63 @@ async def test_x_north_user_email_header_fallback():
 
 
 @pytest.mark.asyncio
+async def test_x_north_user_email_header_alone_is_not_auth_material():
+    """Test X-North-User-Email alone does not select X-North auth."""
+    backend = NorthAuthBackend()
+
+    conn = create_mock_connection(
+        {"X-North-User-Email": "context@company.com"}
+    )
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.token == ""
+    assert user.access_token.claims["email"] is None
+    assert user.access_token.claims["connector_access_tokens"] == {}
+
+
+@pytest.mark.asyncio
+async def test_legacy_bearer_fallback_with_user_email_context_header():
+    """Test X-North-User-Email alone does not block legacy bearer auth."""
+    from north_mcp_python_sdk.auth import AuthHeaderTokens
+
+    backend = NorthAuthBackend()
+
+    user_token = jwt.encode(
+        payload={"email": "legacy@company.com"}, key="test"
+    )
+    legacy_header = AuthHeaderTokens(
+        user_id_token=user_token,
+        connector_access_tokens={"legacy": "legacy_token"},
+    )
+    legacy_b64 = base64.b64encode(
+        json.dumps(legacy_header.model_dump()).encode()
+    ).decode()
+
+    conn = create_mock_connection(
+        {
+            "Authorization": f"Bearer {legacy_b64}",
+            "X-North-User-Email": "context@company.com",
+        }
+    )
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.claims["email"] == "legacy@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "legacy": "legacy_token"
+    }
+
+
+@pytest.mark.asyncio
 async def test_x_north_connector_tokens_without_id_token_open_auth():
     """Test connector tokens can provide context without an ID token in open auth mode."""
     backend = NorthAuthBackend()

--- a/tests/test_x_north_trusted_issuers.py
+++ b/tests/test_x_north_trusted_issuers.py
@@ -116,6 +116,21 @@ async def test_trusted_issuers_require_auth_headers():
 
 
 @pytest.mark.asyncio
+async def test_trusted_issuers_reject_email_header_without_id_token():
+    backend = NorthAuthBackend(
+        trusted_issuers=["https://example.okta.com"],
+    )
+    conn = create_mock_connection(
+        {"X-North-User-Email": "fallback@company.com"}
+    )
+
+    with pytest.raises(
+        AuthenticationError, match="invalid authorization header"
+    ):
+        await backend.authenticate(conn)
+
+
+@pytest.mark.asyncio
 async def test_trusted_issuers_reject_connector_tokens_without_id_token():
     backend = NorthAuthBackend(
         trusted_issuers=["https://example.okta.com"],

--- a/uv.lock
+++ b/uv.lock
@@ -767,7 +767,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -788,7 +788,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.0.0,<4" },
+    { name = "fastmcp", specifier = ">=3.0.0,<3.4.3" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
 ]


### PR DESCRIPTION
## What changed
- Released the SDK as `0.4.4`.
- Tightened the FastMCP dependency from `>=3.0.0,<4` to `>=3.0.0,<3.4.3` so fresh installs avoid FastMCP `3.4.3`.
- Removed `X-North-User-Email` from the set of headers that select the X-North auth path.
- Kept `X-North-User-Email` as fallback user context when `X-North-ID-Token` or `X-North-Connector-Tokens` already selected X-North auth.
- Regenerated `uv.lock` and added regression coverage for the email-header behavior.

## Context
SDK `0.4.3` allowed any FastMCP `3.x`, so a fresh install could resolve to FastMCP `3.4.3`. That version added stricter route-level bearer behavior that can reject requests before North's `X-North-*` auth middleware can satisfy them. This patch keeps SDK consumers on the tested FastMCP 3.0-3.4.2 range while we handle FastMCP 3.4.3+ compatibility directly.

This PR also fixes a separate auth-context issue noticed while testing the pin. North may send `X-North-User-Email` as user context, but email alone is not authentication material. The SDK should not treat an email-only request as an authenticated X-North request; it should only use that email after stronger North headers have selected the X-North path.

## How to verify
- `uv run pytest tests/test_x_north_auth_backend.py tests/test_x_north_trusted_issuers.py`
- `uv run pytest`
- `uv run ruff check .`

## Reviewer focus
- The temporary FastMCP bound: `<3.4.3` versus excluding only `!=3.4.3`.
- The auth semantics: `X-North-User-Email` remains fallback context, but no longer counts as auth material by itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authentication header selection changed in a security-sensitive path; dependency pin affects all consumers until FastMCP 3.4.3+ compatibility is fixed in the SDK.
> 
> **Overview**
> Releases **0.4.4** and caps **FastMCP** at `>=3.0.0,<3.4.3` so fresh installs do not pull **3.4.3**, which rejects MCP requests before North’s `X-North-*` auth can run.
> 
> **`NorthAuthBackend._has_x_north_headers`** no longer treats **`X-North-User-Email`** alone as X-North auth material—only **`X-North-ID-Token`** and **`X-North-Connector-Tokens`** select that path. Email remains a **fallback context** when those headers are already in play; email-only requests fall through to open-auth empty context or legacy bearer / trusted-issuer rules instead of pseudo-authenticating via email.
> 
> Tests cover email-only open auth, bearer + email context, and trusted-issuer rejection when only email is sent; lockfile updated for the new dependency bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b32a5dd5fdc7c74e0c3097c9c419db2ffb97696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
