### PR TITLE
fix(auth): allow empty legacy context in open auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "north-mcp-python-sdk"
-version = "0.4.4"
+version = "0.4.5"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Raphael Cristal", email = "raphael@cohere.com" }]

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -391,7 +391,7 @@ class NorthAuthBackend(AuthenticationBackend):
         )
 
     async def _authenticate_legacy_bearer(
-        self, conn: HTTPConnection
+        self, conn: HTTPConnection, *, require_id_token: bool = True
     ) -> tuple[AuthCredentials, BaseUser]:
         """Authenticate using legacy Authorization Bearer header (backwards compatibility)."""
         self.logger.debug(
@@ -434,9 +434,11 @@ class NorthAuthBackend(AuthenticationBackend):
 
         if not tokens.user_id_token:
             self.logger.debug("No user ID token present in bearer token")
-            raise AuthenticationError("no authentication headers present")
-
-        email = self._process_user_id_token(tokens.user_id_token)
+            if require_id_token:
+                raise AuthenticationError("no authentication headers present")
+            email = None
+        else:
+            email = self._process_user_id_token(tokens.user_id_token)
 
         self.logger.debug("Legacy authentication successful")
         return self._create_authenticated_user(
@@ -465,7 +467,9 @@ class NorthAuthBackend(AuthenticationBackend):
                 self.logger.debug(
                     "No auth configured, but Authorization header is present; parsing legacy request context without enforcing authentication"
                 )
-                return await self._authenticate_legacy_bearer(conn)
+                return await self._authenticate_legacy_bearer(
+                    conn, require_id_token=False
+                )
 
             self.logger.debug(
                 "No trusted issuer configuration present and no auth headers provided; skipping authentication"

--- a/src/north_mcp_python_sdk/auth.py
+++ b/src/north_mcp_python_sdk/auth.py
@@ -39,6 +39,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 class AuthHeaderTokens(BaseModel):
     user_id_token: str | None
+    user_email: str | None = None
     connector_access_tokens: dict[str, str] = Field(default_factory=dict)
 
 
@@ -436,9 +437,11 @@ class NorthAuthBackend(AuthenticationBackend):
             self.logger.debug("No user ID token present in bearer token")
             if require_id_token:
                 raise AuthenticationError("no authentication headers present")
-            email = None
+            token_email = None
         else:
-            email = self._process_user_id_token(tokens.user_id_token)
+            token_email = self._process_user_id_token(tokens.user_id_token)
+
+        email = token_email if token_email is not None else tokens.user_email
 
         self.logger.debug("Legacy authentication successful")
         return self._create_authenticated_user(

--- a/tests/test_north_token_verifier.py
+++ b/tests/test_north_token_verifier.py
@@ -186,6 +186,31 @@ class TestNorthTokenVerifierIntegration:
         )
         assert response.status_code != 401
 
+    @pytest.mark.asyncio
+    async def test_mcp_route_allows_empty_legacy_context_in_open_auth(
+        self, fastmcp_with_north_auth
+    ):
+        """Legacy clients may send an auth bundle without an ID token."""
+        auth_data = {
+            "user_id_token": None,
+            "connector_access_tokens": {},
+            "server_secret": None,
+        }
+        auth_header = base64.b64encode(json.dumps(auth_data).encode()).decode()
+
+        response = await fastmcp_with_north_auth.post(
+            "/mcp",
+            headers={"Authorization": auth_header},
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {},
+            },
+        )
+
+        assert response.status_code != 401
+
 
 class TestOnAuthError:
     """Test the on_auth_error helper function."""

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -190,6 +190,31 @@ async def test_legacy_bearer_without_id_token_open_auth():
 
 
 @pytest.mark.asyncio
+async def test_current_legacy_bundle_uses_user_email_without_id_token():
+    """Test the current North legacy bundle preserves user email context."""
+    backend = NorthAuthBackend()
+    legacy_header = {
+        "user_id_token": None,
+        "user_email": "legacy@company.com",
+        "connector_access_tokens": {"github": "token123"},
+    }
+    legacy_b64 = base64.b64encode(json.dumps(legacy_header).encode()).decode()
+    conn = create_mock_connection({"Authorization": legacy_b64})
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.token == ""
+    assert user.access_token.claims["email"] == "legacy@company.com"
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "github": "token123"
+    }
+
+
+@pytest.mark.asyncio
 async def test_minimal_x_north_headers():
     """Test X-North with minimal supported headers."""
     backend = NorthAuthBackend()

--- a/tests/test_x_north_auth_backend.py
+++ b/tests/test_x_north_auth_backend.py
@@ -165,6 +165,31 @@ async def test_legacy_bearer_fallback():
 
 
 @pytest.mark.asyncio
+async def test_legacy_bearer_without_id_token_open_auth():
+    """Test legacy context without an ID token is accepted in open auth mode."""
+    backend = NorthAuthBackend()
+    legacy_header = {
+        "user_id_token": None,
+        "connector_access_tokens": {"github": "token123"},
+        "server_secret": None,
+    }
+    legacy_b64 = base64.b64encode(json.dumps(legacy_header).encode()).decode()
+    conn = create_mock_connection({"Authorization": legacy_b64})
+
+    auth_response = await backend.authenticate(conn)
+    if auth_response is None:
+        raise ValueError("Authentication response is None")
+    _, user = auth_response
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.access_token.token == ""
+    assert user.access_token.claims["email"] is None
+    assert user.access_token.claims["connector_access_tokens"] == {
+        "github": "token123"
+    }
+
+
+@pytest.mark.asyncio
 async def test_minimal_x_north_headers():
     """Test X-North with minimal supported headers."""
     backend = NorthAuthBackend()

--- a/tests/test_x_north_trusted_issuers.py
+++ b/tests/test_x_north_trusted_issuers.py
@@ -116,6 +116,25 @@ async def test_trusted_issuers_require_auth_headers():
 
 
 @pytest.mark.asyncio
+async def test_trusted_issuers_reject_legacy_bearer_without_id_token():
+    backend = NorthAuthBackend(
+        trusted_issuers=["https://example.okta.com"],
+    )
+    legacy_header = {
+        "user_id_token": None,
+        "connector_access_tokens": {},
+        "server_secret": None,
+    }
+    legacy_b64 = base64.b64encode(json.dumps(legacy_header).encode()).decode()
+    conn = create_mock_connection({"Authorization": legacy_b64})
+
+    with pytest.raises(
+        AuthenticationError, match="no authentication headers present"
+    ):
+        await backend.authenticate(conn)
+
+
+@pytest.mark.asyncio
 async def test_trusted_issuers_reject_email_header_without_id_token():
     backend = NorthAuthBackend(
         trusted_issuers=["https://example.okta.com"],

--- a/uv.lock
+++ b/uv.lock
@@ -767,7 +767,7 @@ wheels = [
 
 [[package]]
 name = "north-mcp-python-sdk"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- give legacy `Authorization` bundles parity with the modern `X-North-*` path in open-auth mode
- accept legacy request context without a user ID token only when no trusted issuers are configured
- preserve strict ID-token enforcement when `trusted_issuers` are configured
- bump the SDK and lockfile to `0.4.5`

## Root cause

North environments with legacy MCP headers enabled can emit a valid legacy authorization bundle with `user_id_token: null` when OIDC token resolution is unavailable. SDK 0.4.2+ rejected that bundle even when authentication was otherwise open, while an equivalent request with no header—or modern connector context since 0.4.3—was accepted. This caused MCP registration to fail with `401 no authentication headers present` before application-level custom-header authorization could run.

## Impact

Older North environments can continue sending legacy request context to modern MCP servers without restoring deprecated server-secret authentication. Configurations using trusted issuers remain protected and continue rejecting requests without an ID token.

## Validation

- `uv run pytest -q` — 141 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- regression coverage includes the exact legacy bundle shape with `server_secret: null`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and request-context parsing; behavior change is limited to servers without trusted issuers, but misconfiguration could weaken expectations around ID tokens.
> 
> **Overview**
> Fixes **401** on MCP when North sends a legacy base64 `Authorization` bundle with `user_id_token: null` while the server runs in **open auth** (no `trusted_issuers`). That path already accepted equivalent `X-North-*` context; legacy bearer now matches it.
> 
> `_authenticate_legacy_bearer` gains `require_id_token` (default **true**). Open-auth handling passes `require_id_token=False` so connector tokens and optional `user_email` on `AuthHeaderTokens` are still parsed. With **trusted issuers** configured, missing ID token still fails with `no authentication headers present`.
> 
> Release **0.4.5**; regression tests cover empty legacy bundles, `user_email` without ID token, and strict mode rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de67dc8d488cf575029e3d2c5170edbba4486f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->