### PR TITLE
docs(citations): update example for North 1.13 schema

### DIFF
--- a/examples/server_with_citations.py
+++ b/examples/server_with_citations.py
@@ -15,7 +15,7 @@ Keep `title` and `url` at the top level too. North uses those fields when
 labelling the tool result in the thinking UI.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from north_mcp_python_sdk import NorthMCPServer
@@ -55,7 +55,7 @@ def search_knowledge_base(query: str) -> list[dict[str, Any]]:
                 "meta": {
                     "author_name": "Wikipedia Contributors",
                     "last_updated": str(
-                        int(datetime(2024, 1, 15).timestamp())
+                        int(datetime(2024, 1, 15, tzinfo=UTC).timestamp())
                     ),
                 },
             },
@@ -72,7 +72,7 @@ def search_knowledge_base(query: str) -> list[dict[str, Any]]:
                 "meta": {
                     "author_name": "Tim Peters",
                     "last_updated": str(
-                        int(datetime(2004, 8, 23).timestamp())
+                        int(datetime(2004, 8, 23, tzinfo=UTC).timestamp())
                     ),
                 },
             },

--- a/examples/server_with_citations.py
+++ b/examples/server_with_citations.py
@@ -4,15 +4,19 @@ Example: Returning Citations with Tool Results
 Use the `_north_metadata` field to provide citation information
 that the North UI will display alongside results.
 
-Supported metadata fields:
-- title: Document or page title
-- url: Source URL
-- author_name: Author of the content
-- last_updated: Unix timestamp of last update
-- page_number: Page number in document
+Document citation metadata requires:
+- renderer: "document"
+- content: Text displayed in the citation
+
+Optional document fields include `title`, `url`, `label`, and `meta`.
+Author, update time, and page number belong inside `meta`.
+
+Keep `title` and `url` at the top level too. North uses those fields when
+labelling the tool result in the thinking UI.
 """
 
 from datetime import datetime
+from typing import Any
 
 from north_mcp_python_sdk import NorthMCPServer
 
@@ -20,33 +24,57 @@ mcp = NorthMCPServer("Citations Demo")
 
 
 @mcp.tool()
-def search_knowledge_base(query: str) -> list[dict[str, str | dict[str, str]]]:
+def search_knowledge_base(query: str) -> list[dict[str, Any]]:
     """Search the knowledge base and return results with citations."""
+    python_text = (
+        "Python is a high-level programming language known for its "
+        "clear syntax and readability. It supports multiple programming "
+        "paradigms including procedural, object-oriented, and functional."
+    )
+    python_title = "Python (programming language) - Wikipedia"
+    python_url = "https://en.wikipedia.org/wiki/Python_(programming_language)"
+
+    zen_text = (
+        "The Zen of Python emphasizes code readability and simplicity. "
+        "Key principles include 'Beautiful is better than ugly' and "
+        "'Simple is better than complex'."
+    )
+    zen_title = "PEP 20 – The Zen of Python"
+    zen_url = "https://peps.python.org/pep-0020/"
+
     return [
         {
-            "text": (
-                "Python is a high-level programming language known for its "
-                "clear syntax and readability. It supports multiple programming "
-                "paradigms including procedural, object-oriented, and functional."
-            ),
+            "text": python_text,
+            "title": python_title,
+            "url": python_url,
             "_north_metadata": {
-                "title": "Python (programming language) - Wikipedia",
-                "url": "https://en.wikipedia.org/wiki/Python_(programming_language)",
-                "author_name": "Wikipedia Contributors",
-                "last_updated": str(int(datetime(2024, 1, 15).timestamp())),
+                "renderer": "document",
+                "content": python_text,
+                "title": python_title,
+                "url": python_url,
+                "meta": {
+                    "author_name": "Wikipedia Contributors",
+                    "last_updated": str(
+                        int(datetime(2024, 1, 15).timestamp())
+                    ),
+                },
             },
         },
         {
-            "text": (
-                "The Zen of Python emphasizes code readability and simplicity. "
-                "Key principles include 'Beautiful is better than ugly' and "
-                "'Simple is better than complex'."
-            ),
+            "text": zen_text,
+            "title": zen_title,
+            "url": zen_url,
             "_north_metadata": {
-                "title": "PEP 20 – The Zen of Python",
-                "url": "https://peps.python.org/pep-0020/",
-                "author_name": "Tim Peters",
-                "last_updated": str(int(datetime(2004, 8, 23).timestamp())),
+                "renderer": "document",
+                "content": zen_text,
+                "title": zen_title,
+                "url": zen_url,
+                "meta": {
+                    "author_name": "Tim Peters",
+                    "last_updated": str(
+                        int(datetime(2004, 8, 23).timestamp())
+                    ),
+                },
             },
         },
     ]


### PR DESCRIPTION
## What changed
- Add the required `renderer` and `content` fields to document citation metadata.
- Move author and update-time attributes under the citation `meta` object.
- Keep `title` and `url` at the top level so North can label tool results in the thinking UI.

## Context
North 1.13 validates `_north_metadata` against its current citation schema and no longer promotes nested fields to the top-level tool result. The previous example omitted the required citation content and relied on the old flattening behavior, causing its metadata to be discarded.

## How to verify
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` (142 passed)
- `uv run python -m compileall -q examples/server_with_citations.py`
- `git diff --check`
- Validated both example payloads directly against the citation model shipped in North app `v0.329.4` (North Platform 1.13.2).

## Reviewer focus
- The deliberate duplication of `title` and `url`: nested values drive citation rendering, while top-level values label the result in the thinking UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and documentation only; no SDK or runtime behavior changes.
> 
> **Overview**
> Updates **`examples/server_with_citations.py`** so citation payloads match **North 1.13** validation instead of the old metadata shape that could be dropped.
> 
> The module docstring now documents **document** citations: required **`renderer: "document"`** and **`content`**, optional fields, and **`author_name` / `last_updated`** under **`meta`**, with **`title` / `url`** duplicated at the tool-result top level for the thinking UI.
> 
> Each sample hit sets top-level **`title`**, **`url`**, and **`_north_metadata`** with the new structure; timestamps use **timezone-aware** `datetime(..., tzinfo=UTC)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54b1f55e9bea7d04ee6e368213da26584a1501f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->